### PR TITLE
Fixes for KillEvent

### DIFF
--- a/src/main/java/com/theminequest/MineQuest/Events/MQEventManager.java
+++ b/src/main/java/com/theminequest/MineQuest/Events/MQEventManager.java
@@ -31,6 +31,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 
@@ -197,7 +198,6 @@ public class MQEventManager implements Listener, EventManager {
 	 * @see com.theminequest.MineQuest.Events.EventManager#onEntityDamageByEntityEvent(org.bukkit.event.entity.EntityDamageByEntityEvent)
 	 */
 	@Override
-	@EventHandler(priority = EventPriority.HIGHEST)
 	public void onEntityDamageByEntityEvent(final EntityDamageByEntityEvent e){
 		synchronized(activeevents){
 			for (int i=0; i<activeevents.size(); i++){
@@ -207,6 +207,13 @@ public class MQEventManager implements Listener, EventManager {
 				if (a.isComplete()!=null)
 					i--;
 			}
+		}
+	}
+
+	@EventHandler(priority = EventPriority.HIGHEST)
+	public void onEntityDamageEvent(final EntityDamageEvent e){
+		if (e instanceof EntityDamageByEntityEvent) {
+			onEntityDamageByEntityEvent((EntityDamageByEntityEvent) e);
 		}
 	}
 

--- a/src/main/java/com/theminequest/MineQuest/Quest/QuestManager.java
+++ b/src/main/java/com/theminequest/MineQuest/Quest/QuestManager.java
@@ -82,15 +82,13 @@ import static com.theminequest.MineQuest.API.Quest.QuestDetails.*;
 public class QuestManager implements Listener, com.theminequest.MineQuest.API.Quest.QuestManager {
 
 	protected final String locationofQuests;
-	private LinkedHashMap<Long,Quest> quests;
-	private List<QuestDetails> descriptions;
-	private long questid;
-	private final QuestParser parser;
+	private LinkedHashMap<Long,Quest> quests = new LinkedHashMap<Long,Quest>();
+	private List<QuestDetails> descriptions = new ArrayList<QuestDetails>();
+	private long questid = 0;
+	private final QuestParser parser = new QuestParser();
 
 	public QuestManager(){
 		Managers.log("[Quest] Starting Manager...");
-		quests = new LinkedHashMap<Long,Quest>();
-		questid = 0;
 		locationofQuests = MineQuest.configuration.questConfig
 				.getString("questfolderlocation",
 						Managers.getActivePlugin().getDataFolder().getAbsolutePath()
@@ -100,7 +98,6 @@ public class QuestManager implements Listener, com.theminequest.MineQuest.API.Qu
 			f.delete();
 			f.mkdirs();
 		}
-		parser = new QuestParser();
 		parser.addClassHandler("accepttext", AcceptTextHandler.class);
 		parser.addClassHandler("canceltext", CancelTextHandler.class);
 		parser.addClassHandler("description", DescriptionHandler.class);
@@ -123,7 +120,7 @@ public class QuestManager implements Listener, com.theminequest.MineQuest.API.Qu
 	@Override
 	public synchronized void reloadQuests(){
 		Managers.log("[Quest] Reload Triggered. Starting reload...");
-		descriptions = new ArrayList<QuestDetails>();
+		descriptions.clear();
 		File file = new File(locationofQuests);
 		for (File f : file.listFiles(new FilenameFilter(){
 


### PR DESCRIPTION
I noticed kill events were broken in 1.2.5.  I ported the patches forward to Minequest 2.0.  These work in 1.2.5, but untested in 2.0, but I assume they still work.
